### PR TITLE
Implement retry policies and update SQL schema

### DIFF
--- a/Models/Liquidacion.cs
+++ b/Models/Liquidacion.cs
@@ -1,0 +1,10 @@
+namespace Nomina.WorkerTimbrado.Models
+{
+    public class Liquidacion
+    {
+        public int IdLiquidacion { get; set; }
+        public int IdCompania { get; set; }
+        public int Intentos { get; set; }
+        public short UltimoIntento { get; set; }
+    }
+}

--- a/Models/WorkerSettings.cs
+++ b/Models/WorkerSettings.cs
@@ -1,0 +1,12 @@
+namespace Nomina.WorkerTimbrado.Models
+{
+    public class WorkerSettings
+    {
+        public string ConnectionString { get; set; } = string.Empty;
+        public string ApiBaseUrl { get; set; } = string.Empty;
+        public int PollIntervalSeconds { get; set; } = 60;
+        public int MaxRetryCount { get; set; } = 3;
+        public int BatchSize { get; set; } = 50;
+        public int BackoffMinutes { get; set; } = 5;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,31 @@
-using TimbradoNominaService;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Nomina.WorkerTimbrado;
+using Nomina.WorkerTimbrado.Models;
+using Nomina.WorkerTimbrado.Services;
+using Polly;
 
-IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
+var builder = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((context, services) =>
     {
-        services.AddHostedService<Worker>();
-    })
-    .Build();
+        services.Configure<WorkerSettings>(context.Configuration.GetSection("WorkerSettings"));
+        services.AddHttpClient<TimbradoApiClient>((sp, client) =>
+        {
+            var settings = sp.GetRequiredService<IOptions<WorkerSettings>>().Value;
+            client.BaseAddress = new Uri(settings.ApiBaseUrl);
+            client.Timeout = TimeSpan.FromSeconds(30);
+        }).AddTransientHttpErrorPolicy(builder =>
+            builder.WaitAndRetryAsync(3, retry => TimeSpan.FromSeconds(Math.Pow(2, retry))));
 
+        services.AddTransient<LiquidacionRepository>(sp =>
+        {
+            var settings = sp.GetRequiredService<IOptions<WorkerSettings>>().Value;
+            return new LiquidacionRepository(settings.ConnectionString);
+        });
+
+        services.AddHostedService<Worker>();
+    });
+
+var host = builder.Build();
 await host.RunAsync();

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "profiles": {
-    "TimbradoNominaService": {
+    "Nomina.WorkerTimbrado": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "environmentVariables": {

--- a/Services/LiquidacionRepository.cs
+++ b/Services/LiquidacionRepository.cs
@@ -1,0 +1,109 @@
+using System.Data;
+using System.Data.SqlClient;
+using Nomina.WorkerTimbrado.Models;
+
+namespace Nomina.WorkerTimbrado.Services
+{
+    public class LiquidacionRepository
+    {
+        private readonly string _connectionString;
+
+        public LiquidacionRepository(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        private SqlConnection CreateConnection()
+            => new SqlConnection(_connectionString);
+
+        public async Task<List<Liquidacion>> GetPendientesAsync(int batchSize, CancellationToken ct)
+        {
+            var list = new List<Liquidacion>();
+            const string query = @"SELECT TOP(@BatchSize) IdLiquidacion, IdCompania, Intentos, UltimoIntento
+                                    FROM cfdi.liquidacionOperador
+                                    WHERE Estatus = 0
+                                      AND (FechaProximoIntento IS NULL OR FechaProximoIntento <= SYSUTCDATETIME())
+                                    ORDER BY FechaRegistro";
+            using var conn = CreateConnection();
+            using var cmd = new SqlCommand(query, conn);
+            cmd.Parameters.AddWithValue("@BatchSize", batchSize);
+            await conn.OpenAsync(ct);
+            using var reader = await cmd.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
+            {
+                list.Add(new Liquidacion
+                {
+                    IdLiquidacion = reader.GetInt32(0),
+                    IdCompania = reader.GetInt32(1),
+                    Intentos = reader.GetInt32(2),
+                    UltimoIntento = reader.GetInt16(3)
+                });
+            }
+            return list;
+        }
+
+        public async Task<bool> MarcarEnProcesoAsync(Liquidacion liq, CancellationToken ct)
+        {
+            const string update = @"UPDATE cfdi.liquidacionOperador
+                                     SET Estatus = 1,
+                                         Intentos = Intentos + 1,
+                                         UltimoIntento = Intentos + 1
+                                   WHERE IdLiquidacion = @IdLiquidacion
+                                     AND IdCompania = @IdCompania
+                                     AND Estatus = 0";
+            using var conn = CreateConnection();
+            using var cmd = new SqlCommand(update, conn);
+            cmd.Parameters.AddWithValue("@IdLiquidacion", liq.IdLiquidacion);
+            cmd.Parameters.AddWithValue("@IdCompania", liq.IdCompania);
+            await conn.OpenAsync(ct);
+            var rows = await cmd.ExecuteNonQueryAsync(ct);
+            return rows > 0;
+        }
+
+        public async Task SetRequiereRevisionAsync(Liquidacion liq, CancellationToken ct)
+        {
+            const string update = @"UPDATE cfdi.liquidacionOperador
+                                     SET Estatus = 6
+                                   WHERE IdLiquidacion = @IdLiquidacion
+                                     AND IdCompania = @IdCompania";
+            using var conn = CreateConnection();
+            using var cmd = new SqlCommand(update, conn);
+            cmd.Parameters.AddWithValue("@IdLiquidacion", liq.IdLiquidacion);
+            cmd.Parameters.AddWithValue("@IdCompania", liq.IdCompania);
+            await conn.OpenAsync(ct);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        public async Task SetErrorTransitorioAsync(Liquidacion liq, int backoffMinutes, CancellationToken ct)
+        {
+            const string update = @"UPDATE cfdi.liquidacionOperador
+                                     SET Estatus = 4,
+                                         FechaProximoIntento = DATEADD(MINUTE, @Backoff, SYSUTCDATETIME())
+                                   WHERE IdLiquidacion = @IdLiquidacion
+                                     AND IdCompania = @IdCompania";
+            using var conn = CreateConnection();
+            using var cmd = new SqlCommand(update, conn);
+            cmd.Parameters.AddWithValue("@IdLiquidacion", liq.IdLiquidacion);
+            cmd.Parameters.AddWithValue("@IdCompania", liq.IdCompania);
+            cmd.Parameters.AddWithValue("@Backoff", backoffMinutes);
+            await conn.OpenAsync(ct);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        public async Task SetErrorAsync(Liquidacion liq, int status, string message, CancellationToken ct)
+        {
+            const string update = @"UPDATE cfdi.liquidacionOperador
+                                     SET Estatus = @Status, MensajeCorto = @Mensaje
+                                   WHERE IdLiquidacion = @IdLiquidacion
+                                     AND IdCompania = @IdCompania";
+            using var conn = CreateConnection();
+            using var cmd = new SqlCommand(update, conn);
+            cmd.Parameters.AddWithValue("@Status", status);
+            cmd.Parameters.AddWithValue("@Mensaje", message);
+            cmd.Parameters.AddWithValue("@IdLiquidacion", liq.IdLiquidacion);
+            cmd.Parameters.AddWithValue("@IdCompania", liq.IdCompania);
+            await conn.OpenAsync(ct);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+    }
+}

--- a/Services/TimbradoApiClient.cs
+++ b/Services/TimbradoApiClient.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Logging;
+using System.Net.Http.Json;
+using Nomina.WorkerTimbrado.Models;
+
+namespace Nomina.WorkerTimbrado.Services
+{
+    public class TimbradoApiClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<TimbradoApiClient> _logger;
+
+        public TimbradoApiClient(HttpClient httpClient, ILogger<TimbradoApiClient> logger)
+        {
+            _httpClient = httpClient;
+            _logger = logger;
+        }
+
+        public async Task<HttpResponseMessage> TimbrarAsync(Liquidacion liq, CancellationToken ct)
+        {
+            var url = $"api/timbrar/{liq.IdLiquidacion}/{liq.IdCompania}";
+            try
+            {
+                _logger.LogInformation("Invocando {Url}", url);
+                return await _httpClient.PostAsync(url, null, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error HTTP invocando {Url}", url);
+                throw;
+            }
+        }
+    }
+}

--- a/TimbradoNominaService.csproj
+++ b/TimbradoNominaService.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Nomina.WorkerTimbrado</RootNamespace>
+    <AssemblyName>Nomina.WorkerTimbrado</AssemblyName>
     <UserSecretsId>dotnet-TimbradoNominaService-0ed2eede-d2d2-4d8b-8339-aeaa2ce29aaf</UserSecretsId>
   </PropertyGroup>
 
@@ -16,5 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Worker.cs
+++ b/Worker.cs
@@ -1,20 +1,84 @@
-namespace TimbradoNominaService
+using Microsoft.Extensions.Options;
+using Nomina.WorkerTimbrado.Models;
+using Nomina.WorkerTimbrado.Services;
+
+namespace Nomina.WorkerTimbrado
 {
     public class Worker : BackgroundService
     {
         private readonly ILogger<Worker> _logger;
+        private readonly LiquidacionRepository _repository;
+        private readonly WorkerSettings _settings;
+        private readonly TimbradoApiClient _apiClient;
 
-        public Worker(ILogger<Worker> logger)
+        public Worker(ILogger<Worker> logger,
+                       LiquidacionRepository repository,
+                       IOptions<WorkerSettings> settings,
+                       TimbradoApiClient apiClient)
         {
             _logger = logger;
+            _repository = repository;
+            _settings = settings.Value;
+            _apiClient = apiClient;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                await Task.Delay(1000, stoppingToken);
+                try
+                {
+                    await ProcessPendingAsync(stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error en ciclo principal");
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(_settings.PollIntervalSeconds), stoppingToken);
+            }
+        }
+
+        private async Task ProcessPendingAsync(CancellationToken ct)
+        {
+            var pendientes = await _repository.GetPendientesAsync(_settings.BatchSize, ct);
+            _logger.LogInformation("Se encontraron {count} liquidaciones pendientes", pendientes.Count);
+
+            foreach (var liq in pendientes)
+            {
+                if (liq.Intentos >= _settings.MaxRetryCount)
+                {
+                    await _repository.SetRequiereRevisionAsync(liq, ct);
+                    _logger.LogWarning("Liquidacion {liq} de compania {comp} excede reintentos", liq.IdLiquidacion, liq.IdCompania);
+                    continue;
+                }
+
+                if (!await _repository.MarcarEnProcesoAsync(liq, ct))
+                {
+                    _logger.LogInformation("Liquidacion {liq} ya esta siendo procesada", liq.IdLiquidacion);
+                    continue;
+                }
+
+                try
+                {
+                    var response = await _apiClient.TimbrarAsync(liq, ct);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        _logger.LogInformation("HTTP OK para liquidacion {liq}", liq.IdLiquidacion);
+                        continue;
+                    }
+
+                    var mensaje = await response.Content.ReadAsStringAsync(ct);
+                    int status = response.StatusCode >= System.Net.HttpStatusCode.BadRequest &&
+                                 response.StatusCode < System.Net.HttpStatusCode.InternalServerError ? 2 : 3;
+                    await _repository.SetErrorAsync(liq, status, mensaje, ct);
+                    _logger.LogError("Error respuesta API {status} para liquidacion {liq}", response.StatusCode, liq.IdLiquidacion);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error transitorio para liquidacion {liq}", liq.IdLiquidacion);
+                    await _repository.SetErrorTransitorioAsync(liq, _settings.BackoffMinutes, ct);
+                }
             }
         }
     }

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,8 +1,16 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Debug",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "WorkerSettings": {
+    "ConnectionString": "Server=.;Database=Timbrado;Trusted_Connection=True;",
+    "ApiBaseUrl": "https://localhost/",
+    "PollIntervalSeconds": 30,
+    "MaxRetryCount": 3,
+    "BatchSize": 20,
+    "BackoffMinutes": 5
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -4,5 +4,13 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "WorkerSettings": {
+    "ConnectionString": "Server=.;Database=Timbrado;Trusted_Connection=True;",
+    "ApiBaseUrl": "https://mi-dominio/",
+    "PollIntervalSeconds": 60,
+    "MaxRetryCount": 3,
+    "BatchSize": 50,
+    "BackoffMinutes": 5
   }
 }


### PR DESCRIPTION
## Summary
- inject repository directly into Worker and use HttpClient with Polly retries
- update SQL queries to use `cfdi.liquidacionOperador` and track `UltimoIntento`
- register repository via DI and add Polly package

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447ce95720832f851d1d068cf2433e